### PR TITLE
feat: remove plugins which do not report line numbers for high seas

### DIFF
--- a/repositories/heartbeat.go
+++ b/repositories/heartbeat.go
@@ -49,6 +49,20 @@ func (r *HeartbeatRepository) InsertBatch(heartbeats []*models.Heartbeat) error 
 		return nil
 	}
 
+	filteredHeartbeats := heartbeats[:0]
+
+	for _, hb := range heartbeats {
+		if hb.Lines != 0 {
+			filteredHeartbeats = append(filteredHeartbeats, hb)
+		}
+	}
+
+	heartbeats = filteredHeartbeats
+
+	if len(heartbeats) == 0 {
+		return nil
+	}
+
 	if err := r.db.
 		Clauses(clause.OnConflict{
 			DoNothing: true,


### PR DESCRIPTION
To fix: https://github.com/hackclub/high-seas/issues/539

It should filter all heartbeats that don't have a lines attribute.