### PR TITLE
fix: not displaying correctly when easyeda is displayed

### DIFF
--- a/data/colors.json
+++ b/data/colors.json
@@ -626,7 +626,7 @@
         "DataGrip": "#907cf2",
         "DBeaver": "#897363",
         "Easyeda": "#5588ff",
-        "Easyedapro": "##5588ff",
+        "Easyedapro": "#5588ff",
         "Eclipse": "#443582",
         "Emacs": "#8c76c3",
         "Embarcadero Delphi": "#d9242a",


### PR DESCRIPTION
Removes the mistakenly added double `#`
![image](https://github.com/user-attachments/assets/204ac015-efe0-47cf-a88f-c03aa0e10eb6)
![image](https://github.com/user-attachments/assets/87de3dc0-016d-43c7-ab1e-82175d335574)
